### PR TITLE
feat: adding custom classes and types

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,29 +149,28 @@ own special behavior for tiles or objects.
 Even though the structure explained above should always be followed, the developer can ask Leap
 to use different classes, types, names.
 
-In order to do so, a custom `LeapConfiguration` can be passed whe loading a map (or instantiating it manually)
+In order to do so, a custom `LeapConfiguration` can be passed to the game.
 
 Example:
 
 ```dart
-final customConfiguration = LeapConfiguration(
-  tiled: const TiledOptions(
-    groundLayerName: 'Ground',
-    metadataLayerName: 'Metadata',
-    playerSpawnClass: 'PlayerSpawn',
-    hazardClass: 'Hazard',
-    damageProperty: 'Damage',
-    platformClass: 'Platform',
-    slopeType: 'Slope',
-    slopeRightTopProperty: 'RightTop',
-    slopeLeftTopProperty: 'LeftTop',
-  ),
-);
-
-await loadWorldAndMap(
-  ...,
-  configuration: customConfiguration,
-);
+class MyLeapGame extend Leap {
+  MyLeapGame() : super(
+    configuration: LeapConfiguration(
+      tiled: const TiledOptions(
+        groundLayerName: 'Ground',
+        metadataLayerName: 'Metadata',
+        playerSpawnClass: 'PlayerSpawn',
+        hazardClass: 'Hazard',
+        damageProperty: 'Damage',
+        platformClass: 'Platform',
+        slopeType: 'Slope',
+        slopeRightTopProperty: 'RightTop',
+        slopeLeftTopProperty: 'LeftTop',
+      ),
+    ),
+  );
+}
 ```
 
 ## Roadmap 🚧

--- a/README.md
+++ b/README.md
@@ -149,10 +149,10 @@ own special behavior for tiles or objects.
 Even though the structure explained above should always be followed, the developer can ask Leap
 to use different classes, types, names.
 
-In order to do so, set a new `LeapOptions` to `LeapOptions.defaults` before loading a map:
+In order to do so, set a new `TiledOptions` to `LeapConfiguration.tiled` before loading a map:
 
 ```dart
-LeapOptions.defaults = const LeapOptions(
+LeapConfiguration.tiled = const TiledOptions(
     groundLayerName: 'Ground',
     metadataLayerName: 'Metadata',
     playerSpawnClass: 'PlayerSpawn',

--- a/README.md
+++ b/README.md
@@ -144,6 +144,27 @@ Any other layers will be rendered visually but have no impact on the game automa
 additional custom behavior by accessing the layers via `LeapGame.map.tiledMap` and integrating your
 own special behavior for tiles or objects.
 
+#### Customizing layer names and classes
+
+Even though the structure explained above should always be followed, the developer can ask Leap
+to use different classes, types, names.
+
+In order to do so, set a new `LeapOptions` to `LeapOptions.defaults` before loading a map:
+
+```dart
+LeapOptions.defaults = const LeapOptions(
+    groundLayerName: 'Ground',
+    metadataLayerName: 'Metadata',
+    playerSpawnClass: 'PlayerSpawn',
+    hazardClass: 'Hazard',
+    damageProperty: 'Damage',
+    platformClass: 'Platform',
+    slopeType: 'Slope',
+    slopeRightTopProperty: 'RightTop',
+    slopeLeftTopProperty: 'LeftTop',
+  );
+```
+
 ## Roadmap 🚧
 
 - Improved collision detection API.

--- a/README.md
+++ b/README.md
@@ -149,10 +149,13 @@ own special behavior for tiles or objects.
 Even though the structure explained above should always be followed, the developer can ask Leap
 to use different classes, types, names.
 
-In order to do so, set a new `TiledOptions` to `LeapConfiguration.tiled` before loading a map:
+In order to do so, a custom `LeapConfiguration` can be passed whe loading a map (or instantiating it manually)
+
+Example:
 
 ```dart
-LeapConfiguration.tiled = const TiledOptions(
+final customConfiguration = LeapConfiguration(
+  tiled: const TiledOptions(
     groundLayerName: 'Ground',
     metadataLayerName: 'Metadata',
     playerSpawnClass: 'PlayerSpawn',
@@ -162,7 +165,13 @@ LeapConfiguration.tiled = const TiledOptions(
     slopeType: 'Slope',
     slopeRightTopProperty: 'RightTop',
     slopeLeftTopProperty: 'LeftTop',
-  );
+  ),
+);
+
+await loadWorldAndMap(
+  ...,
+  configuration: customConfiguration,
+);
 ```
 
 ## Roadmap 🚧

--- a/examples/standard_platformer/pubspec.lock
+++ b/examples/standard_platformer/pubspec.lock
@@ -201,7 +201,7 @@ packages:
       path: "../../packages/leap"
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.2.0"
   material_color_utilities:
     dependency: transitive
     description:

--- a/examples/standard_platformer/pubspec.yaml
+++ b/examples/standard_platformer/pubspec.yaml
@@ -8,9 +8,9 @@ environment:
   flutter: 3.13.2
 
 dependencies:
-  flame: ^1.9.1
+  flame: ^1.10.0
   flame_audio: ^2.1.1
-  flame_tiled: ^1.14.1
+  flame_tiled: ^1.15.0
   flutter:
     sdk: flutter
   leap:

--- a/packages/leap/lib/leap.dart
+++ b/packages/leap/lib/leap.dart
@@ -3,4 +3,5 @@ export 'src/entities/entities.dart';
 export 'src/input.dart';
 export 'src/leap_game.dart';
 export 'src/leap_map.dart';
+export 'src/leap_options.dart';
 export 'src/leap_world.dart';

--- a/packages/leap/lib/src/leap_game.dart
+++ b/packages/leap/lib/src/leap_game.dart
@@ -12,6 +12,7 @@ class LeapGame extends FlameGame with HasTrackedComponents {
   LeapGame({
     required this.tileSize,
     this.appState = AppLifecycleState.resumed,
+    this.configuration = const LeapConfiguration(),
   }) : super(world: LeapWorld(tileSize: tileSize));
 
   final double tileSize;
@@ -19,6 +20,8 @@ class LeapGame extends FlameGame with HasTrackedComponents {
   late final LeapMap leapMap;
 
   AppLifecycleState appState;
+
+  final LeapConfiguration configuration;
 
   @override
   void lifecycleStateChange(AppLifecycleState state) {
@@ -56,7 +59,7 @@ class LeapGame extends FlameGame with HasTrackedComponents {
       prefix: prefix,
       bundle: bundle,
       images: images,
-      configuration: configuration,
+      tiledOptions: configuration.tiled,
     );
 
     await world.add(leapMap);

--- a/packages/leap/lib/src/leap_game.dart
+++ b/packages/leap/lib/src/leap_game.dart
@@ -4,6 +4,7 @@ import 'package:flame/cache.dart';
 import 'package:flame/components.dart';
 import 'package:flame/game.dart';
 import 'package:flutter/services.dart';
+import 'package:leap/leap.dart';
 import 'package:leap/src/entities/entities.dart';
 import 'package:leap/src/leap_map.dart';
 import 'package:leap/src/leap_world.dart';
@@ -46,6 +47,7 @@ class LeapGame extends FlameGame with HasTrackedComponents {
     String prefix = 'assets/tiles/',
     AssetBundle? bundle,
     Images? images,
+    LeapConfiguration configuration = const LeapConfiguration(),
   }) async {
     camera.world = world;
 
@@ -57,6 +59,7 @@ class LeapGame extends FlameGame with HasTrackedComponents {
       prefix: prefix,
       bundle: bundle,
       images: images,
+      configuration: configuration,
     );
 
     await world.add(leapMap);

--- a/packages/leap/lib/src/leap_game.dart
+++ b/packages/leap/lib/src/leap_game.dart
@@ -5,9 +5,6 @@ import 'package:flame/components.dart';
 import 'package:flame/game.dart';
 import 'package:flutter/services.dart';
 import 'package:leap/leap.dart';
-import 'package:leap/src/entities/entities.dart';
-import 'package:leap/src/leap_map.dart';
-import 'package:leap/src/leap_world.dart';
 import 'package:leap/src/mixins/mixins.dart';
 
 /// A [FlameGame] with all the Leap built-ins.

--- a/packages/leap/lib/src/leap_map.dart
+++ b/packages/leap/lib/src/leap_map.dart
@@ -9,7 +9,7 @@ import 'package:leap/leap.dart';
 class LeapMap extends PositionComponent with HasGameRef<LeapGame> {
   LeapMap({required this.tileSize, required this.tiledMap}) {
     groundLayer = getTileLayer<TileLayer>(
-      LeapOptions.defaults.groundLayerName,
+      LeapConfiguration.tiled.groundLayerName,
     );
 
     // Size of the map component is based on the tile map's grid.
@@ -65,11 +65,11 @@ class LeapMap extends PositionComponent with HasGameRef<LeapGame> {
   /// Spawn location for the player.
   Vector2 get playerSpawn {
     final metadataLayer = tiledMap.tileMap.getLayer<ObjectGroup>(
-      LeapOptions.defaults.metadataLayerName,
+      LeapConfiguration.tiled.metadataLayerName,
     );
     if (metadataLayer != null) {
       final spawn = metadataLayer.objects.firstWhere(
-        (obj) => obj.class_ == LeapOptions.defaults.playerSpawnClass,
+        (obj) => obj.class_ == LeapConfiguration.tiled.playerSpawnClass,
       );
       return Vector2(spawn.x, spawn.y);
     } else {
@@ -123,16 +123,16 @@ class LeapMapGroundTile extends PhysicalEntity {
   late bool isSlope;
 
   /// Hazards (like spikes) damage on collision.
-  bool get isHazard => tile.class_ == LeapOptions.defaults.hazardClass;
+  bool get isHazard => tile.class_ == LeapConfiguration.tiled.hazardClass;
 
   /// Platforms only collide from above so the player can jump through them
   /// and land on top.
-  bool get isPlatform => tile.class_ == LeapOptions.defaults.platformClass;
+  bool get isPlatform => tile.class_ == LeapConfiguration.tiled.platformClass;
 
   /// Damage to apply when colliding and [isHazard].
   int get hazardDamage {
     final damage = tile.properties.getValue<int>(
-      LeapOptions.defaults.damageProperty,
+      LeapConfiguration.tiled.damageProperty,
     );
     return damage ?? 0;
   }
@@ -142,12 +142,12 @@ class LeapMapGroundTile extends PhysicalEntity {
     this.gridX,
     this.gridY,
   ) : super(static: true, collisionType: CollisionType.tilemapGround) {
-    isSlope = tile.type == LeapOptions.defaults.slopeType;
+    isSlope = tile.type == LeapConfiguration.tiled.slopeType;
     rightTop = tile.properties.getValue<int>(
-      LeapOptions.defaults.slopeRightTopProperty,
+      LeapConfiguration.tiled.slopeRightTopProperty,
     );
     leftTop = tile.properties.getValue<int>(
-      LeapOptions.defaults.slopeLeftTopProperty,
+      LeapConfiguration.tiled.slopeLeftTopProperty,
     );
   }
 

--- a/packages/leap/lib/src/leap_map.dart
+++ b/packages/leap/lib/src/leap_map.dart
@@ -2,14 +2,15 @@ import 'package:flame/cache.dart';
 import 'package:flame/components.dart';
 import 'package:flame_tiled/flame_tiled.dart';
 import 'package:flutter/services.dart';
-import 'package:leap/src/entities/entities.dart';
-import 'package:leap/src/leap_game.dart';
+import 'package:leap/leap.dart';
 
 /// This component encapsulates the Tiled map, and in particular builds the
 /// grid of ground tiles that make up the terrain of the game.
 class LeapMap extends PositionComponent with HasGameRef<LeapGame> {
   LeapMap({required this.tileSize, required this.tiledMap}) {
-    groundLayer = getTileLayer<TileLayer>('Ground');
+    groundLayer = getTileLayer<TileLayer>(
+      LeapOptions.defaults.groundLayerName,
+    );
 
     // Size of the map component is based on the tile map's grid.
     width = tiledMap.tileMap.map.width * tileSize;
@@ -63,10 +64,12 @@ class LeapMap extends PositionComponent with HasGameRef<LeapGame> {
 
   /// Spawn location for the player.
   Vector2 get playerSpawn {
-    final metadataLayer = tiledMap.tileMap.getLayer<ObjectGroup>('Metadata');
+    final metadataLayer = tiledMap.tileMap.getLayer<ObjectGroup>(
+      LeapOptions.defaults.metadataLayerName,
+    );
     if (metadataLayer != null) {
       final spawn = metadataLayer.objects.firstWhere(
-        (obj) => obj.class_ == 'PlayerSpawn',
+        (obj) => obj.class_ == LeapOptions.defaults.playerSpawnClass,
       );
       return Vector2(spawn.x, spawn.y);
     } else {
@@ -120,15 +123,18 @@ class LeapMapGroundTile extends PhysicalEntity {
   late bool isSlope;
 
   /// Hazards (like spikes) damage on collision.
-  bool get isHazard => tile.class_ == 'Hazard';
+  bool get isHazard => tile.class_ == LeapOptions.defaults.hazardClass;
 
   /// Platforms only collide from above so the player can jump through them
   /// and land on top.
-  bool get isPlatform => tile.class_ == 'Platform';
+  bool get isPlatform => tile.class_ == LeapOptions.defaults.platformClass;
 
   /// Damage to apply when colliding and [isHazard].
   int get hazardDamage {
-    return tile.properties.getValue<int>('Damage') ?? 0;
+    final damage = tile.properties.getValue<int>(
+        LeapOptions.defaults.damageProperty,
+    );
+    return damage ?? 0;
   }
 
   LeapMapGroundTile(
@@ -136,9 +142,13 @@ class LeapMapGroundTile extends PhysicalEntity {
     this.gridX,
     this.gridY,
   ) : super(static: true, collisionType: CollisionType.tilemapGround) {
-    isSlope = tile.type == 'Slope';
-    rightTop = tile.properties.getValue<int>('RightTop');
-    leftTop = tile.properties.getValue<int>('LeftTop');
+    isSlope = tile.type == LeapOptions.defaults.slopeType;
+    rightTop = tile.properties.getValue<int>(
+      LeapOptions.defaults.slopeRightTopProperty,
+    );
+    leftTop = tile.properties.getValue<int>(
+      LeapOptions.defaults.slopeLeftTopProperty,
+    );
   }
 
   @override

--- a/packages/leap/lib/src/leap_map.dart
+++ b/packages/leap/lib/src/leap_map.dart
@@ -132,7 +132,7 @@ class LeapMapGroundTile extends PhysicalEntity {
   /// Damage to apply when colliding and [isHazard].
   int get hazardDamage {
     final damage = tile.properties.getValue<int>(
-        LeapOptions.defaults.damageProperty,
+      LeapOptions.defaults.damageProperty,
     );
     return damage ?? 0;
   }

--- a/packages/leap/lib/src/leap_map.dart
+++ b/packages/leap/lib/src/leap_map.dart
@@ -10,10 +10,10 @@ class LeapMap extends PositionComponent with HasGameRef<LeapGame> {
   LeapMap({
     required this.tileSize,
     required this.tiledMap,
-    this.configuration = const LeapConfiguration(),
+    this.tiledOptions = const TiledOptions(),
   }) {
     groundLayer = getTileLayer<TileLayer>(
-      configuration.tiled.groundLayerName,
+      tiledOptions.groundLayerName,
     );
 
     // Size of the map component is based on the tile map's grid.
@@ -22,7 +22,7 @@ class LeapMap extends PositionComponent with HasGameRef<LeapGame> {
   }
 
   /// Configuration for the game.
-  final LeapConfiguration configuration;
+  final TiledOptions tiledOptions;
 
   /// Tile size (width and height) in pixels.
   final double tileSize;
@@ -42,7 +42,7 @@ class LeapMap extends PositionComponent with HasGameRef<LeapGame> {
     groundTiles = LeapMapGroundTile.generate(
       tiledMap.tileMap.map,
       groundLayer,
-      configuration: configuration,
+      tiledOptions: tiledOptions,
     );
     add(tiledMap);
     for (final column in groundTiles) {
@@ -73,11 +73,11 @@ class LeapMap extends PositionComponent with HasGameRef<LeapGame> {
   /// Spawn location for the player.
   Vector2 get playerSpawn {
     final metadataLayer = tiledMap.tileMap.getLayer<ObjectGroup>(
-      configuration.tiled.metadataLayerName,
+      tiledOptions.metadataLayerName,
     );
     if (metadataLayer != null) {
       final spawn = metadataLayer.objects.firstWhere(
-        (obj) => obj.class_ == configuration.tiled.playerSpawnClass,
+        (obj) => obj.class_ == tiledOptions.playerSpawnClass,
       );
       return Vector2(spawn.x, spawn.y);
     } else {
@@ -92,7 +92,7 @@ class LeapMap extends PositionComponent with HasGameRef<LeapGame> {
     String prefix = 'assets/tiles/',
     AssetBundle? bundle,
     Images? images,
-    LeapConfiguration configuration = const LeapConfiguration(),
+    TiledOptions tiledOptions = const TiledOptions(),
   }) async {
     final tiledMap = await TiledComponent.load(
       tiledMapPath,
@@ -104,7 +104,7 @@ class LeapMap extends PositionComponent with HasGameRef<LeapGame> {
     return LeapMap(
       tileSize: tileSize,
       tiledMap: tiledMap,
-      configuration: configuration,
+      tiledOptions: tiledOptions,
     );
   }
 }
@@ -115,7 +115,7 @@ class LeapMap extends PositionComponent with HasGameRef<LeapGame> {
 /// For the purposes of collision detection, the hitbox is assumed to be the
 /// entire tile (except when [isSlope] is `true`).
 class LeapMapGroundTile extends PhysicalEntity {
-  final LeapConfiguration configuration;
+  final TiledOptions tiledOptions;
 
   final Tile tile;
 
@@ -135,16 +135,16 @@ class LeapMapGroundTile extends PhysicalEntity {
   late bool isSlope;
 
   /// Hazards (like spikes) damage on collision.
-  bool get isHazard => tile.class_ == configuration.tiled.hazardClass;
+  bool get isHazard => tile.class_ == tiledOptions.hazardClass;
 
   /// Platforms only collide from above so the player can jump through them
   /// and land on top.
-  bool get isPlatform => tile.class_ == configuration.tiled.platformClass;
+  bool get isPlatform => tile.class_ == tiledOptions.platformClass;
 
   /// Damage to apply when colliding and [isHazard].
   int get hazardDamage {
     final damage = tile.properties.getValue<int>(
-      configuration.tiled.damageProperty,
+      tiledOptions.damageProperty,
     );
     return damage ?? 0;
   }
@@ -153,14 +153,14 @@ class LeapMapGroundTile extends PhysicalEntity {
     this.tile,
     this.gridX,
     this.gridY, {
-    this.configuration = const LeapConfiguration(),
+    this.tiledOptions = const TiledOptions(),
   }) : super(static: true, collisionType: CollisionType.tilemapGround) {
-    isSlope = tile.type == configuration.tiled.slopeType;
+    isSlope = tile.type == tiledOptions.slopeType;
     rightTop = tile.properties.getValue<int>(
-      configuration.tiled.slopeRightTopProperty,
+      tiledOptions.slopeRightTopProperty,
     );
     leftTop = tile.properties.getValue<int>(
-      configuration.tiled.slopeLeftTopProperty,
+      tiledOptions.slopeLeftTopProperty,
     );
   }
 
@@ -205,7 +205,7 @@ class LeapMapGroundTile extends PhysicalEntity {
   static List<List<LeapMapGroundTile?>> generate(
     TiledMap tileMap,
     TileLayer groundLayer, {
-    LeapConfiguration configuration = const LeapConfiguration(),
+    TiledOptions tiledOptions = const TiledOptions(),
   }) {
     final groundTiles = List.generate(
       groundLayer.width,
@@ -223,7 +223,7 @@ class LeapMapGroundTile extends PhysicalEntity {
           tile,
           x,
           y,
-          configuration: configuration,
+          tiledOptions: tiledOptions,
         );
       }
     }

--- a/packages/leap/lib/src/leap_options.dart
+++ b/packages/leap/lib/src/leap_options.dart
@@ -2,7 +2,6 @@
 /// customize names and classes that Leap will look for
 /// when reading the map.
 class LeapOptions {
-
   const LeapOptions({
     this.groundLayerName = 'Ground',
     this.metadataLayerName = 'Metadata',

--- a/packages/leap/lib/src/leap_options.dart
+++ b/packages/leap/lib/src/leap_options.dart
@@ -2,9 +2,13 @@
 /// customize different options that Leap will use
 /// when reading the map.
 class LeapConfiguration {
+  const LeapConfiguration({
+    this.tiled = const TiledOptions(),
+  });
+
   /// The tiled options, change it to configure how Leap
   /// interpret the tiled map.
-  static TiledOptions tiled = const TiledOptions();
+  final TiledOptions tiled;
 }
 
 /// A configurable class specifically about Tiled names, classes and etc.

--- a/packages/leap/lib/src/leap_options.dart
+++ b/packages/leap/lib/src/leap_options.dart
@@ -1,8 +1,15 @@
 /// A configurable class that allows the developer to
-/// customize names and classes that Leap will look for
+/// customize different options that Leap will use
 /// when reading the map.
-class LeapOptions {
-  const LeapOptions({
+class LeapConfiguration {
+  /// The tiled options, change it to configure how Leap
+  /// interpret the tiled map.
+  static TiledOptions tiled = const TiledOptions();
+}
+
+/// A configurable class specifically about Tiled names, classes and etc.
+class TiledOptions {
+  const TiledOptions({
     this.groundLayerName = 'Ground',
     this.metadataLayerName = 'Metadata',
     this.playerSpawnClass = 'PlayerSpawn',
@@ -13,9 +20,6 @@ class LeapOptions {
     this.slopeRightTopProperty = 'RightTop',
     this.slopeLeftTopProperty = 'LeftTop',
   });
-
-  /// The default options for Leap.
-  static LeapOptions defaults = const LeapOptions();
 
   /// Which layer name should be used for the player, defaults to "Ground".
   final String groundLayerName;

--- a/packages/leap/lib/src/leap_options.dart
+++ b/packages/leap/lib/src/leap_options.dart
@@ -1,0 +1,50 @@
+/// A configurable class that allows the developer to
+/// customize names and classes that Leap will look for
+/// when reading the map.
+class LeapOptions {
+
+  const LeapOptions({
+    this.groundLayerName = 'Ground',
+    this.metadataLayerName = 'Metadata',
+    this.playerSpawnClass = 'PlayerSpawn',
+    this.hazardClass = 'Hazard',
+    this.damageProperty = 'Damage',
+    this.platformClass = 'Platform',
+    this.slopeType = 'Slope',
+    this.slopeRightTopProperty = 'RightTop',
+    this.slopeLeftTopProperty = 'LeftTop',
+  });
+
+  /// The default options for Leap.
+  static LeapOptions defaults = const LeapOptions();
+
+  /// Which layer name should be used for the player, defaults to "Ground".
+  final String groundLayerName;
+
+  /// Which layer name should be used for the metadata, defaults to "Metadata".
+  final String metadataLayerName;
+
+  /// Which class name should be used for the player spawn point,
+  /// defaults to "PlayerSpawn".
+  final String playerSpawnClass;
+
+  /// Whick class name represents hazard objects, defaults to "Hazard".
+  final String hazardClass;
+
+  /// Which property name represents damage, defaults to "Damage".
+  final String damageProperty;
+
+  /// Which class name represents platform objects, defaults to "Platform".
+  final String platformClass;
+
+  /// Which property name represents the slope type, defaults to "Slope".
+  final String slopeType;
+
+  /// Which property name represents the slope left bottom, defaults to
+  /// "RightTop".
+  final String slopeRightTopProperty;
+
+  /// Which property name represents the slope right bottom, defaults to
+  /// "LeftTop".
+  final String slopeLeftTopProperty;
+}

--- a/packages/leap/pubspec.lock
+++ b/packages/leap/pubspec.lock
@@ -84,11 +84,12 @@ packages:
   flame_behaviors:
     dependency: "direct main"
     description:
-      name: flame_behaviors
-      sha256: e6a7429ed5f16efe7683a63d42f18d6e2c68d6ac3ff0e17f4f62bb224fd294b8
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
+      path: "packages/flame_behaviors"
+      ref: "feat!(flame_behaviors)-migrate-to-flame-v1.8.0"
+      resolved-ref: "9409a5d1bb9639beeeac592f615f4346dfb871e5"
+      url: "https://github.com/VeryGoodOpenSource/flame_behaviors"
+    source: git
+    version: "0.3.0"
   flame_lint:
     dependency: "direct dev"
     description:


### PR DESCRIPTION
This PR gives leap some flexibility by allowing the developer to configure the name of classes and types of some of the objects that leap looks for on the map. This can be useful when for some reason, the developer doesn't have full control of the tiled files.

This PR also ensures that by default, all the configured values, are the ones that were before, ensuring that this will not introducing any breaking change.