### PR TITLE
fix: left tap input broken, cannot turn left

### DIFF
--- a/examples/standard_platformer/pubspec.lock
+++ b/examples/standard_platformer/pubspec.lock
@@ -201,7 +201,7 @@ packages:
       path: "../../packages/leap"
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.2.0"
   material_color_utilities:
     dependency: transitive
     description:

--- a/packages/leap/lib/src/input.dart
+++ b/packages/leap/lib/src/input.dart
@@ -75,8 +75,9 @@ class SimpleTapInput extends PositionComponent
   bool get isPressed => downEvent != null && upEvent == null;
 
   bool get isPressedLeft {
-    if (upEvent != null) {
-      return isPressed && upEvent!.devicePosition.x < gameRef.canvasSize.x / 2;
+    if (downEvent != null) {
+      return isPressed &&
+          downEvent!.devicePosition.x < gameRef.canvasSize.x / 2;
     }
     return false;
   }


### PR DESCRIPTION
Somehow the left "button" stopped working, possibly when we upgraded to Flame 1.9.0