### PR TITLE
feat: allow keyboard keys to be customizable in simple keyboard input 

### DIFF
--- a/packages/leap/lib/src/input.dart
+++ b/packages/leap/lib/src/input.dart
@@ -42,14 +42,10 @@ class SimpleCombinedInput extends Component
       (_tapInput.isPressedRight || _keyboardInput.isPressedRight);
 
   SimpleCombinedInput({
-    Set<PhysicalKeyboardKey>? leftKeys,
-    Set<PhysicalKeyboardKey>? rightKeys,
+    SimpleKeyboardInput? keyboardInput,
   }) {
     _tapInput = SimpleTapInput();
-    _keyboardInput = SimpleKeyboardInput(
-      leftKeys: leftKeys,
-      rightKeys: rightKeys,
-    );
+    _keyboardInput = keyboardInput ?? SimpleKeyboardInput();
     add(_tapInput);
     add(_keyboardInput);
   }

--- a/packages/leap/lib/src/input.dart
+++ b/packages/leap/lib/src/input.dart
@@ -41,12 +41,21 @@ class SimpleCombinedInput extends Component
       _appFocused &&
       (_tapInput.isPressedRight || _keyboardInput.isPressedRight);
 
-  SimpleCombinedInput() {
+  SimpleCombinedInput({
+    Set<PhysicalKeyboardKey>? leftKeys,
+    Set<PhysicalKeyboardKey>? rightKeys,
+  }) {
     _tapInput = SimpleTapInput();
-    _keyboardInput = SimpleKeyboardInput();
+    _keyboardInput = SimpleKeyboardInput(
+      leftKeys: leftKeys,
+      rightKeys: rightKeys,
+    );
     add(_tapInput);
     add(_keyboardInput);
   }
+
+  SimpleKeyboardInput get keyboardInput => _keyboardInput;
+  SimpleTapInput get tapInput => _tapInput;
 
   @override
   void update(double dt) {
@@ -116,19 +125,30 @@ class SimpleTapInput extends PositionComponent
 }
 
 class SimpleKeyboardInput extends Component with KeyboardHandler {
-  SimpleKeyboardInput() : relevantKeys = leftKeys.union(rightKeys);
+  SimpleKeyboardInput({
+    Set<PhysicalKeyboardKey>? leftKeys,
+    Set<PhysicalKeyboardKey>? rightKeys,
+  }) {
+    this.leftKeys = leftKeys ??
+        {
+          PhysicalKeyboardKey.arrowLeft,
+          PhysicalKeyboardKey.keyA,
+          PhysicalKeyboardKey.keyH,
+        };
 
-  static final leftKeys = {
-    PhysicalKeyboardKey.arrowLeft,
-    PhysicalKeyboardKey.keyA,
-    PhysicalKeyboardKey.keyH,
-  };
+    this.rightKeys = rightKeys ??
+        {
+          PhysicalKeyboardKey.arrowRight,
+          PhysicalKeyboardKey.keyD,
+          PhysicalKeyboardKey.keyL,
+        };
 
-  static final rightKeys = {
-    PhysicalKeyboardKey.arrowRight,
-    PhysicalKeyboardKey.keyD,
-    PhysicalKeyboardKey.keyL,
-  };
+    relevantKeys = this.leftKeys.union(this.rightKeys);
+  }
+
+  late final Set<PhysicalKeyboardKey> leftKeys;
+
+  late final Set<PhysicalKeyboardKey> rightKeys;
 
   late final Set<PhysicalKeyboardKey> relevantKeys;
 

--- a/packages/leap/test/input_test.dart
+++ b/packages/leap/test/input_test.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:leap/leap.dart';
+
+void main() {
+  group('input', () {
+    group('SimpleCombinedInput', () {
+      test('has the correct default keys', () {
+        final input = SimpleCombinedInput();
+        expect(
+          input.keyboardInput.leftKeys,
+          equals(
+            {
+              PhysicalKeyboardKey.arrowLeft,
+              PhysicalKeyboardKey.keyA,
+              PhysicalKeyboardKey.keyH,
+            },
+          ),
+        );
+        expect(
+          input.keyboardInput.rightKeys,
+          equals(
+            {
+              PhysicalKeyboardKey.arrowRight,
+              PhysicalKeyboardKey.keyD,
+              PhysicalKeyboardKey.keyL,
+            },
+          ),
+        );
+        expect(
+          input.keyboardInput.relevantKeys,
+          equals(
+            {
+              PhysicalKeyboardKey.arrowLeft,
+              PhysicalKeyboardKey.keyA,
+              PhysicalKeyboardKey.keyH,
+              PhysicalKeyboardKey.arrowRight,
+              PhysicalKeyboardKey.keyD,
+              PhysicalKeyboardKey.keyL,
+            },
+          ),
+        );
+      });
+
+      test('can have custom keys', () {
+        final input = SimpleCombinedInput(
+          leftKeys: {
+            PhysicalKeyboardKey.arrowUp,
+          },
+          rightKeys: {
+            PhysicalKeyboardKey.arrowDown,
+          },
+        );
+        expect(
+          input.keyboardInput.leftKeys,
+          equals(
+            {
+              PhysicalKeyboardKey.arrowUp,
+            },
+          ),
+        );
+        expect(
+          input.keyboardInput.rightKeys,
+          equals(
+            {
+              PhysicalKeyboardKey.arrowDown,
+            },
+          ),
+        );
+        expect(
+          input.keyboardInput.relevantKeys,
+          equals(
+            {
+              PhysicalKeyboardKey.arrowUp,
+              PhysicalKeyboardKey.arrowDown,
+            },
+          ),
+        );
+      });
+    });
+
+    group('SimpleKeyboardInput', () {
+      test('has the correct default keys', () {
+        final input = SimpleKeyboardInput();
+        expect(
+          input.leftKeys,
+          equals(
+            {
+              PhysicalKeyboardKey.arrowLeft,
+              PhysicalKeyboardKey.keyA,
+              PhysicalKeyboardKey.keyH,
+            },
+          ),
+        );
+        expect(
+          input.rightKeys,
+          equals(
+            {
+              PhysicalKeyboardKey.arrowRight,
+              PhysicalKeyboardKey.keyD,
+              PhysicalKeyboardKey.keyL,
+            },
+          ),
+        );
+        expect(
+          input.relevantKeys,
+          equals(
+            {
+              PhysicalKeyboardKey.arrowLeft,
+              PhysicalKeyboardKey.keyA,
+              PhysicalKeyboardKey.keyH,
+              PhysicalKeyboardKey.arrowRight,
+              PhysicalKeyboardKey.keyD,
+              PhysicalKeyboardKey.keyL,
+            },
+          ),
+        );
+      });
+
+      test('can have custom keys', () {
+        final input = SimpleKeyboardInput(
+          leftKeys: {
+            PhysicalKeyboardKey.arrowUp,
+          },
+          rightKeys: {
+            PhysicalKeyboardKey.arrowDown,
+          },
+        );
+        expect(
+          input.leftKeys,
+          equals(
+            {
+              PhysicalKeyboardKey.arrowUp,
+            },
+          ),
+        );
+        expect(
+          input.rightKeys,
+          equals(
+            {
+              PhysicalKeyboardKey.arrowDown,
+            },
+          ),
+        );
+        expect(
+          input.relevantKeys,
+          equals(
+            {
+              PhysicalKeyboardKey.arrowUp,
+              PhysicalKeyboardKey.arrowDown,
+            },
+          ),
+        );
+      });
+    });
+  });
+}

--- a/packages/leap/test/input_test.dart
+++ b/packages/leap/test/input_test.dart
@@ -44,12 +44,14 @@ void main() {
 
       test('can have custom keys', () {
         final input = SimpleCombinedInput(
-          leftKeys: {
-            PhysicalKeyboardKey.arrowUp,
-          },
-          rightKeys: {
-            PhysicalKeyboardKey.arrowDown,
-          },
+          keyboardInput: SimpleKeyboardInput(
+            leftKeys: {
+              PhysicalKeyboardKey.arrowUp,
+            },
+            rightKeys: {
+              PhysicalKeyboardKey.arrowDown,
+            },
+          ),
         );
         expect(
           input.keyboardInput.leftKeys,


### PR DESCRIPTION
Allows the SimpleKeyboardInput and SimpleCombinedInput to have their keyboard keys configured, with the current keys being the defaults.