### PR TITLE
chore:  Clean-up loadWorldAndMap interface

### DIFF
--- a/examples/standard_platformer/lib/main.dart
+++ b/examples/standard_platformer/lib/main.dart
@@ -41,7 +41,6 @@ class ExamplePlatformerLeapGame extends LeapGame
     );
 
     await loadWorldAndMap(
-      camera: camera,
       tiledMapPath: 'map.tmx',
       tiledObjectHandlers: {
         'Coin': await CoinFactory.createFactory(),

--- a/packages/leap/lib/src/leap_game.dart
+++ b/packages/leap/lib/src/leap_game.dart
@@ -43,15 +43,12 @@ class LeapGame extends FlameGame with HasTrackedComponents {
   /// and use tile size [tileSize].
   Future<void> loadWorldAndMap({
     required String tiledMapPath,
-    required CameraComponent camera,
     String prefix = 'assets/tiles/',
     AssetBundle? bundle,
     Images? images,
     LeapConfiguration configuration = const LeapConfiguration(),
     Map<String, TiledObjectHandler> tiledObjectHandlers = const {},
   }) async {
-    camera.world = world;
-
     // These two classes reference each other, so the order matters here to
     // load properly.
     leapMap = await LeapMap.load(

--- a/packages/leap/lib/src/leap_game.dart
+++ b/packages/leap/lib/src/leap_game.dart
@@ -1,7 +1,6 @@
 import 'dart:ui';
 
 import 'package:flame/cache.dart';
-import 'package:flame/components.dart';
 import 'package:flame/game.dart';
 import 'package:flutter/services.dart';
 import 'package:leap/leap.dart';


### PR DESCRIPTION
Removing `camera` from method as it is not necessary