### PR TITLE
feat: allow game to specify max atlas sizes

### DIFF
--- a/packages/leap/lib/src/leap_game.dart
+++ b/packages/leap/lib/src/leap_game.dart
@@ -45,7 +45,6 @@ class LeapGame extends FlameGame with HasTrackedComponents {
     String prefix = 'assets/tiles/',
     AssetBundle? bundle,
     Images? images,
-    LeapConfiguration configuration = const LeapConfiguration(),
     Map<String, TiledObjectHandler> tiledObjectHandlers = const {},
   }) async {
     // These two classes reference each other, so the order matters here to

--- a/packages/leap/lib/src/leap_map.dart
+++ b/packages/leap/lib/src/leap_map.dart
@@ -120,6 +120,8 @@ class LeapMap extends PositionComponent with HasGameRef<LeapGame> {
       prefix: prefix,
       bundle: bundle,
       images: images,
+      atlasMaxX: tiledOptions.atlasMaxX,
+      atlasMaxY: tiledOptions.atlasMaxY,
     );
     return LeapMap(
       tileSize: tileSize,

--- a/packages/leap/lib/src/leap_options.dart
+++ b/packages/leap/lib/src/leap_options.dart
@@ -23,6 +23,8 @@ class TiledOptions {
     this.slopeType = 'Slope',
     this.slopeRightTopProperty = 'RightTop',
     this.slopeLeftTopProperty = 'LeftTop',
+    this.atlasMaxX,
+    this.atlasMaxY,
   });
 
   /// Which layer name should be used for the player, defaults to "Ground".
@@ -54,4 +56,12 @@ class TiledOptions {
   /// Which property name represents the slope right bottom, defaults to
   /// "LeftTop".
   final String slopeLeftTopProperty;
+
+  /// The max width of the atlas texture, defaults to Flame Tiled default
+  /// value when omitted.
+  final double? atlasMaxX;
+
+  /// The max height of the atlas texture, defaults to Flame Tiled default
+  /// value when omitted.
+  final double? atlasMaxY;
 }

--- a/packages/leap/pubspec.lock
+++ b/packages/leap/pubspec.lock
@@ -84,11 +84,12 @@ packages:
   flame_behaviors:
     dependency: "direct main"
     description:
-      name: flame_behaviors
-      sha256: e6a7429ed5f16efe7683a63d42f18d6e2c68d6ac3ff0e17f4f62bb224fd294b8
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
+      path: "packages/flame_behaviors"
+      ref: "feat!(flame_behaviors)-migrate-to-flame-v1.8.0"
+      resolved-ref: "9409a5d1bb9639beeeac592f615f4346dfb871e5"
+      url: "https://github.com/VeryGoodOpenSource/flame_behaviors"
+    source: git
+    version: "0.3.0"
   flame_lint:
     dependency: "direct dev"
     description:


### PR DESCRIPTION
FlameTiled allows us to specify what are the max dimensions of the atlas used to pack the images in a map, but there were no way to specify them when using Leap helper to load map, this PR address that.