### PR TITLE
feat: adding tsx packing filter to TiledOptions

### DIFF
--- a/packages/leap/lib/src/leap_map.dart
+++ b/packages/leap/lib/src/leap_map.dart
@@ -123,6 +123,7 @@ class LeapMap extends PositionComponent with HasGameRef<LeapGame> {
       images: images,
       atlasMaxX: tiledOptions.atlasMaxX,
       atlasMaxY: tiledOptions.atlasMaxY,
+      tsxPackingFilter: tiledOptions.tsxPackingFilter,
     );
     return LeapMap(
       tileSize: tileSize,

--- a/packages/leap/lib/src/leap_options.dart
+++ b/packages/leap/lib/src/leap_options.dart
@@ -1,3 +1,5 @@
+import 'package:tiled/tiled.dart';
+
 /// A configurable class that allows the developer to
 /// customize different options that Leap will use
 /// when reading the map.
@@ -25,6 +27,7 @@ class TiledOptions {
     this.slopeLeftTopProperty = 'LeftTop',
     this.atlasMaxX,
     this.atlasMaxY,
+    this.tsxPackingFilter,
   });
 
   /// Which layer name should be used for the player, defaults to "Ground".
@@ -64,4 +67,11 @@ class TiledOptions {
   /// The max height of the atlas texture, defaults to Flame Tiled default
   /// value when omitted.
   final double? atlasMaxY;
+
+  /// A filter that allows you to filter which tilesets should be packed
+  /// into Flame Tiled Texture Atlas.
+  ///
+  /// When omitted defaults to Flame Tiled's default filter, which include all
+  /// tilesets in the atlas.
+  final bool Function(Tileset)? tsxPackingFilter;
 }

--- a/packages/leap/pubspec.lock
+++ b/packages/leap/pubspec.lock
@@ -100,12 +100,11 @@ packages:
   flame_tiled:
     dependency: "direct main"
     description:
-      path: "packages/flame_tiled"
-      ref: HEAD
-      resolved-ref: b93bdd38313fd273e3e4cf55f1b142969effbde4
-      url: "https://github.com/flame-engine/flame.git"
-    source: git
-    version: "1.15.1"
+      name: flame_tiled
+      sha256: "72afc84f73b93a7d52fb636fd02f059f47db0f482145829070b301ab33794d23"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.16.0"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/packages/leap/pubspec.lock
+++ b/packages/leap/pubspec.lock
@@ -77,10 +77,10 @@ packages:
     dependency: "direct main"
     description:
       name: flame
-      sha256: "042533edc7ded96c2a439b2eae1a905f2611447d0d106b33686b841371c8d8c5"
+      sha256: b6bb76224fc29fd5eea25d66cda6e322e3678bdedc1f65956c6151326a6a798b
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.1"
   flame_behaviors:
     dependency: "direct main"
     description:
@@ -100,11 +100,12 @@ packages:
   flame_tiled:
     dependency: "direct main"
     description:
-      name: flame_tiled
-      sha256: "1d40c455612ed5a0b471bff5e86f06964f9be3039a8b69000359b4a27184d39e"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.15.0"
+      path: "packages/flame_tiled"
+      ref: HEAD
+      resolved-ref: b93bdd38313fd273e3e4cf55f1b142969effbde4
+      url: "https://github.com/flame-engine/flame.git"
+    source: git
+    version: "1.15.1"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/packages/leap/pubspec.yaml
+++ b/packages/leap/pubspec.yaml
@@ -10,17 +10,11 @@ environment:
 dependencies:
   flame: ^1.10.0
   flame_behaviors: ^1.0.0
-  flame_tiled: ^1.15.0
+  flame_tiled: ^1.16.0
   flutter:
     sdk: flutter
   pathxp: ^0.4.0
   tiled: ^0.10.1
-
-dependency_overrides:
-  flame_tiled:
-    git:
-      url: https://github.com/flame-engine/flame.git
-      path: packages/flame_tiled
 
 dev_dependencies:
   flame_lint: ^1.1.1

--- a/packages/leap/pubspec.yaml
+++ b/packages/leap/pubspec.yaml
@@ -16,6 +16,12 @@ dependencies:
   pathxp: ^0.4.0
   tiled: ^0.10.1
 
+dependency_overrides:
+  flame_tiled:
+    git:
+      url: https://github.com/flame-engine/flame.git
+      path: packages/flame_tiled
+
 dev_dependencies:
   flame_lint: ^1.1.1
   flutter_test:


### PR DESCRIPTION
Adds a new options to `TiledOptions` to make use of the new added option on Flame Tiled when loading maps.

Marking as draft until we get a new Flame Tiled release.