### PR TITLE
feat: Adding atlas packing spacing option to TiledOptions

### DIFF
--- a/packages/leap/lib/src/leap_map.dart
+++ b/packages/leap/lib/src/leap_map.dart
@@ -126,6 +126,8 @@ class LeapMap extends PositionComponent with HasGameRef<LeapGame> {
       tsxPackingFilter: tiledOptions.tsxPackingFilter,
       useAtlas: tiledOptions.useAtlas,
       layerPaintFactory: tiledOptions.layerPaintFactory,
+      atlasPackingSpacingX: tiledOptions.atlasPackingSpacingX,
+      atlasPackingSpacingY: tiledOptions.atlasPackingSpacingY,
     );
     return LeapMap(
       tileSize: tileSize,

--- a/packages/leap/lib/src/leap_options.dart
+++ b/packages/leap/lib/src/leap_options.dart
@@ -31,6 +31,8 @@ class TiledOptions {
     this.tsxPackingFilter,
     this.useAtlas = true,
     this.layerPaintFactory,
+    this.atlasPackingSpacingX = 0,
+    this.atlasPackingSpacingY = 0,
   });
 
   /// Which layer name should be used for the player, defaults to "Ground".
@@ -93,4 +95,12 @@ class TiledOptions {
   /// When ommited, resorts to Flame Tiled one, which creates a
   /// a white Paint with the layer opacity value.
   final Paint Function(double opacity)? layerPaintFactory;
+
+  /// The horizontal spacing between tilesets in the atlas texture,
+  /// defaults to 0.
+  final double atlasPackingSpacingX;
+
+  /// The vertical between tilesets in the atlas texture,
+  /// defaults to 0.
+  final double atlasPackingSpacingY;
 }

--- a/packages/leap/pubspec.lock
+++ b/packages/leap/pubspec.lock
@@ -76,10 +76,9 @@ packages:
   flame:
     dependency: "direct main"
     description:
-      name: flame
-      sha256: b6bb76224fc29fd5eea25d66cda6e322e3678bdedc1f65956c6151326a6a798b
-      url: "https://pub.dev"
-    source: hosted
+      path: "../../../flame/packages/flame"
+      relative: true
+    source: path
     version: "1.10.1"
   flame_behaviors:
     dependency: "direct main"
@@ -100,10 +99,9 @@ packages:
   flame_tiled:
     dependency: "direct main"
     description:
-      name: flame_tiled
-      sha256: "38d03b94b27299d321d325c6aea54023bd793ae167c6c7f92fb7de81a5acfd4f"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../../../flame/packages/flame_tiled"
+      relative: true
+    source: path
     version: "1.17.0"
   flutter:
     dependency: "direct main"

--- a/packages/leap/pubspec.yaml
+++ b/packages/leap/pubspec.yaml
@@ -16,6 +16,10 @@ dependencies:
   pathxp: ^0.4.0
   tiled: ^0.10.1
 
+dependency_overrides:
+  flame_tiled:
+    path: ../../../flame/packages/flame_tiled
+
 dev_dependencies:
   flame_lint: ^1.1.1
   flutter_test:


### PR DESCRIPTION
Adds new tiled options to TiledOptions to allow developers to configure the atlas spacing attributes.

Marking as draft while https://github.com/flame-engine/flame/pull/2868 isn't merged and release.