### PR TITLE
feat!: refactoring collision info (again) and adding character animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,11 +143,11 @@ it dies.
 ##### Character animations
 
 Characters are typically rendered visually as a `SpriteAnimation`, however most
-likely thre is a different animation for different states of the character.
+likely there is a different animation for different states of the character.
 That's where `CharacterAnimation` comes in.
 
-A `CharacterAnimation` is specialized `SpriteAnimationGroupComponent`, so you
-can set all the animations as map on the component and the update the current
+A `CharacterAnimation` is a specialized `SpriteAnimationGroupComponent`, so you
+can set all the animations as map on the component and then update the current
 animation with the key in the map for the correct animation.
 
 Typically you want to make use of this by making a subclass of

--- a/examples/standard_platformer/lib/coin.dart
+++ b/examples/standard_platformer/lib/coin.dart
@@ -25,9 +25,8 @@ class Coin extends PhysicalEntity {
 
   final SpriteAnimation animation;
 
-  @override
-  void onRemove() {
-    super.onRemove();
+  void collect() {
+    removeFromParent();
     FlameAudio.play('coin.wav');
   }
 }

--- a/examples/standard_platformer/lib/player.dart
+++ b/examples/standard_platformer/lib/player.dart
@@ -32,7 +32,6 @@ class Player extends JumperCharacter<ExamplePlatformerLeapGame> {
     _spawn = map.playerSpawn;
 
     characterAnimation = PlayerSpriteAnimation();
-    add(characterAnimation!);
 
     // Size controls player hitbox, which should be slightly smaller than
     // visual size of the sprite.
@@ -297,6 +296,8 @@ class PlayerSpriteAnimation extends CharacterAnimation<_AnimationState, Player>
         ),
       ),
     };
+
+    current = _AnimationState.idle;
 
     return super.onLoad();
   }

--- a/packages/leap/lib/src/characters/jumper_character.dart
+++ b/packages/leap/lib/src/characters/jumper_character.dart
@@ -1,13 +1,10 @@
-import 'package:flame/components.dart';
 import 'package:leap/src/characters/jumper_behavior.dart';
-import 'package:leap/src/entities/character.dart';
+import 'package:leap/src/entities/entities.dart';
 import 'package:leap/src/leap_game.dart';
 
 class JumperCharacter<TGame extends LeapGame> extends Character<TGame> {
-  JumperCharacter({
-    super.health = 10,
-    super.removeOnDeath,
-  }) : super(behaviors: [JumperBehavior()]);
+  JumperCharacter({super.removeOnDeath, super.health})
+      : super(behaviors: [JumperBehavior()]);
 
   /// When true the character is facing left, otherwise right.
   bool faceLeft = false;
@@ -32,9 +29,6 @@ class JumperCharacter<TGame extends LeapGame> extends Character<TGame> {
   /// The last ground velocity of the character on the horizontal axis.
   double airXVelocity = 0;
 
-  /// The animation position component of the character.
-  PositionComponent? spriteAnimation;
-
   /// Stop walking.
   void stand() => walking = false;
 
@@ -49,16 +43,12 @@ class JumperCharacter<TGame extends LeapGame> extends Character<TGame> {
   void update(double dt) {
     super.update(dt);
 
-    if (spriteAnimation == null) {
-      return;
-    }
-
-    if (velocity.x < 0) {
-      spriteAnimation!.transform.offset.x = spriteAnimation!.width - width;
-      spriteAnimation!.scale.x = -1;
-    } else if (velocity.x > 0) {
-      spriteAnimation!.transform.offset.x = 0;
-      spriteAnimation!.scale.x = 1;
+    if (characterAnimation != null) {
+      if (velocity.x < 0) {
+        characterAnimation!.scale.x = -characterAnimation!.scale.x.abs();
+      } else if (velocity.x > 0) {
+        characterAnimation!.scale.x = characterAnimation!.scale.x.abs();
+      }
     }
   }
 }

--- a/packages/leap/lib/src/entities/character.dart
+++ b/packages/leap/lib/src/entities/character.dart
@@ -10,6 +10,7 @@ class Character<T extends LeapGame> extends PhysicalEntity<T> {
   Character({
     this.health = 1,
     this.removeOnDeath = true,
+    this.finishAnimationBeforeRemove = false,
     super.static,
     super.behaviors,
     super.priority,
@@ -25,6 +26,12 @@ class Character<T extends LeapGame> extends PhysicalEntity<T> {
   /// Indicates if this should [remove] itself on death.
   bool removeOnDeath;
 
+  bool _removingFromDeath = false;
+
+  /// Indicates if this finish the current [characterAnimation] before
+  /// auto-removing (i.e. [removeOnDeath]).
+  bool finishAnimationBeforeRemove = true;
+
   /// Whether or not this is "alive" (or not destroyed) in the game
   bool get isAlive => health > 0;
 
@@ -35,6 +42,8 @@ class Character<T extends LeapGame> extends PhysicalEntity<T> {
 
   /// Indicates that this was alive on the previous [update] loop
   bool get wasAlive => _wasAlive;
+
+  CharacterAnimation? characterAnimation;
 
   /// Called when this entity dies, typically due to health dropping below one.
   ///
@@ -51,9 +60,16 @@ class Character<T extends LeapGame> extends PhysicalEntity<T> {
 
     if (isDead && wasAlive) {
       if (removeOnDeath) {
-        removeFromParent();
+        _removingFromDeath = true;
       }
       onDeath();
+    }
+    if (_removingFromDeath &&
+        (!finishAnimationBeforeRemove ||
+            (characterAnimation == null ||
+                (characterAnimation!.animationTicker?.done() ?? false)))) {
+      _removingFromDeath = false;
+      removeFromParent();
     }
 
     _wasAlive = isAlive;

--- a/packages/leap/lib/src/entities/character.dart
+++ b/packages/leap/lib/src/entities/character.dart
@@ -5,7 +5,6 @@ import 'package:leap/leap.dart';
 /// for players, enemies, etc.
 /// Characters have health, and usually a removed on death.
 ///
-// TODO(kurtome): add sprite animation and state helpers.
 class Character<T extends LeapGame> extends PhysicalEntity<T> {
   Character({
     this.health = 1,
@@ -30,7 +29,7 @@ class Character<T extends LeapGame> extends PhysicalEntity<T> {
 
   /// Indicates if this finish the current [characterAnimation] before
   /// auto-removing (i.e. [removeOnDeath]).
-  bool finishAnimationBeforeRemove = true;
+  bool finishAnimationBeforeRemove = false;
 
   /// Whether or not this is "alive" (or not destroyed) in the game
   bool get isAlive => health > 0;
@@ -43,7 +42,17 @@ class Character<T extends LeapGame> extends PhysicalEntity<T> {
   /// Indicates that this was alive on the previous [update] loop
   bool get wasAlive => _wasAlive;
 
-  CharacterAnimation? characterAnimation;
+  CharacterAnimation? _characterAnimation;
+  CharacterAnimation? get characterAnimation => _characterAnimation;
+  set characterAnimation(CharacterAnimation? newAnimation) {
+    if (_characterAnimation != null) {
+      remove(_characterAnimation!);
+    }
+    _characterAnimation = newAnimation;
+    if (_characterAnimation != null) {
+      add(_characterAnimation!);
+    }
+  }
 
   /// Called when this entity dies, typically due to health dropping below one.
   ///

--- a/packages/leap/lib/src/entities/character_animation.dart
+++ b/packages/leap/lib/src/entities/character_animation.dart
@@ -1,0 +1,52 @@
+import 'package:flame/components.dart';
+import 'package:flutter/foundation.dart';
+import 'package:leap/leap.dart';
+
+abstract class CharacterAnimation<T, C extends Character>
+    extends SpriteAnimationGroupComponent<T> with HasAncestor<C> {
+  CharacterAnimation({
+    this.hitboxAnchor = Anchor.bottomCenter,
+    super.animations,
+    super.autoResize = true, // probably want to auto-resize
+    super.removeOnFinish,
+    super.playing,
+    super.paint,
+    super.position,
+    super.size,
+    super.scale,
+    super.angle,
+    super.nativeAngle,
+    super.anchor,
+    super.children,
+    super.priority,
+    super.key,
+  });
+
+  /// Where the sprite should be in relation to the parent hitbox.
+  /// For example, [Anchor.bottomCenter] means the parent hitbox should be
+  /// flush with the bottom of the animation and centered horizontally.
+  Anchor hitboxAnchor;
+
+  /// The parent character this is added to.
+  C get character => ancestor;
+
+  T? _prevCurrent;
+
+  @override
+  @mustCallSuper
+  void update(double dt) {
+    if (_prevCurrent != current) {
+      // Assume that we want to start the new animation at the beginning,
+      // not wherever it last left off.
+      animationTicker?.reset();
+    }
+    _prevCurrent = current;
+
+    // Do this _after_ setting the animation since
+    // that may have caused a resize.
+    x = (ancestor.width - width * scale.x) * hitboxAnchor.x;
+    y = (ancestor.height - height * scale.y) * hitboxAnchor.y;
+
+    super.update(dt);
+  }
+}

--- a/packages/leap/lib/src/entities/entities.dart
+++ b/packages/leap/lib/src/entities/entities.dart
@@ -1,3 +1,5 @@
+export 'character.dart';
+export 'character_animation.dart';
 export 'common_tags.dart';
 export 'ladder.dart';
 export 'moving_platform.dart';

--- a/packages/leap/lib/src/entities/physical_entity.dart
+++ b/packages/leap/lib/src/entities/physical_entity.dart
@@ -64,10 +64,14 @@ abstract class PhysicalEntity<TGame extends LeapGame> extends PositionedEntity
           ),
         );
 
-  /// Draws a rect over the hitbox when this returns true.
+  /// Draws a rect over the hitbox when this is true.
   bool debugHitbox = false;
 
+  /// Draws a rect over the hitbox of collisions when is true.
+  bool debugCollisions = false;
+
   _DebugHitboxComponent? _debugHitboxComponent;
+  _DebugCollisionsComponent? _debugCollisionsComponent;
 
   @override
   @mustCallSuper
@@ -90,6 +94,19 @@ abstract class PhysicalEntity<TGame extends LeapGame> extends PositionedEntity
       if (_debugHitboxComponent != null) {
         _debugHitboxComponent!.removeFromParent();
         _debugHitboxComponent = null;
+      }
+    }
+
+    // Adds a visualization for the entity's collisions dynamically
+    if (debugCollisions) {
+      if (_debugCollisionsComponent == null) {
+        _debugCollisionsComponent = _DebugCollisionsComponent();
+        add(_debugCollisionsComponent!);
+      }
+    } else {
+      if (_debugCollisionsComponent != null) {
+        _debugCollisionsComponent!.removeFromParent();
+        _debugCollisionsComponent = null;
       }
     }
   }
@@ -274,10 +291,36 @@ class _DebugHitboxComponent extends PositionComponent {
   final _paint = Paint()..color = Colors.green.withOpacity(0.6);
 
   @override
-  int get priority => 999;
+  int get priority => 9998;
 
   @override
   void render(Canvas canvas) {
     canvas.drawRect(size.toRect(), _paint);
+  }
+}
+
+/// Component added as a child to ensure it is drawn on top of the
+/// entity's standard rendering.
+class _DebugCollisionsComponent extends PositionComponent
+    with HasAncestor<PhysicalEntity> {
+  final _paint = Paint()..color = Colors.red.withOpacity(0.6);
+
+  @override
+  int get priority => 9999;
+
+  @override
+  void render(Canvas canvas) {
+    for (final collision in ancestor.collisionInfo.allCollisions) {
+      final left = collision.x - ancestor.x;
+      final top = collision.y - ancestor.y;
+      final rect = Rect.fromLTRB(
+        left,
+        top,
+        left + collision.width,
+        top + collision.height,
+      );
+
+      canvas.drawRect(rect, _paint);
+    }
   }
 }

--- a/packages/leap/lib/src/entities/status.dart
+++ b/packages/leap/lib/src/entities/status.dart
@@ -21,9 +21,32 @@ class StatusComponent extends PositionComponent {
 }
 
 /// A status mixin which indicates the parent entity should not
+/// be considered part of the physical world anymore. This means
+/// it will not be moved by gravity or velocity (unless you manually
+/// update the position) and it will be completely ignored by the collision
+/// system so nothing else will collide with it.
+mixin IgnoredByWorld on StatusComponent {}
+
+/// A status mixin which indicates the parent entity should not
 /// be affected by gravity while the status is present.
 mixin IgnoresGravity on StatusComponent {}
 
 /// A status mixin which indicates the parent entity should not
-/// collide with ground.
+/// be automatically moved by its velocity.
+mixin IgnoresVelocity on StatusComponent {}
+
+/// A status mixin which indicates the parent entity should not
+/// be eligible to collide with by others.
+mixin IgnoredByCollisions on StatusComponent {}
+
+/// A status mixin which indicates the parent entity should not
+/// collide attempt to collide with other things.
+mixin IgnoresCollisions on StatusComponent {}
+
+/// A status mixin which indicates the parent entity should not
+/// collide with solids (ground).
 mixin IgnoresSolidCollisions on StatusComponent {}
+
+/// A status mixin which indicates the parent entity should not
+/// collide with non-solids.
+mixin IgnoresNonSolidCollisions on StatusComponent {}

--- a/packages/leap/lib/src/input/four_button_input.dart
+++ b/packages/leap/lib/src/input/four_button_input.dart
@@ -122,9 +122,9 @@ class FourButtonTapInput extends PositionComponent
   }
 
   @override
-  Future<void> onLoad() async {
-    size = game.leapMap.size;
-    return super.onLoad();
+  void onGameResize(Vector2 size) {
+    super.onGameResize(size);
+    this.size.setFrom(size);
   }
 
   @override

--- a/packages/leap/lib/src/input/three_button_input.dart
+++ b/packages/leap/lib/src/input/three_button_input.dart
@@ -108,9 +108,9 @@ class ThreeButtonTapInput extends PositionComponent
   }
 
   @override
-  Future<void> onLoad() async {
-    size = game.leapMap.size;
-    return super.onLoad();
+  void onGameResize(Vector2 size) {
+    super.onGameResize(size);
+    this.size.setFrom(size);
   }
 
   @override

--- a/packages/leap/lib/src/input/two_button_input.dart
+++ b/packages/leap/lib/src/input/two_button_input.dart
@@ -86,9 +86,9 @@ class TwoButtonTapInput extends PositionComponent
   bool get isPressedRight => isPressed && !isPressedLeft;
 
   @override
-  Future<void> onLoad() async {
-    size = game.world.map.size;
-    return super.onLoad();
+  void onGameResize(Vector2 size) {
+    super.onGameResize(size);
+    this.size.setFrom(size);
   }
 
   @override

--- a/packages/leap/lib/src/leap_game.dart
+++ b/packages/leap/lib/src/leap_game.dart
@@ -1,8 +1,6 @@
-import 'dart:ui';
-
 import 'package:flame/cache.dart';
 import 'package:flame/game.dart';
-import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:leap/leap.dart';
 
 /// A [FlameGame] with all the Leap built-ins.

--- a/packages/leap/lib/src/leap_world.dart
+++ b/packages/leap/lib/src/leap_world.dart
@@ -29,7 +29,11 @@ class LeapWorld extends World with HasGameRef<LeapGame>, HasTimeScale {
   void update(double dt) {
     final gAccel = gravity * dt;
     for (final physical in physicals.where(
-      (p) => !p.static && !p.hasStatus<IgnoresGravity>(),
+      (p) =>
+          !p.static &&
+          p.statuses
+              .where((s) => s is IgnoresGravity || s is IgnoredByWorld)
+              .isEmpty,
     )) {
       final y = physical.velocity.y;
       final desiredVelocity = (gAccel * physical.gravityRate) + y;

--- a/packages/leap/lib/src/physical_behaviors/collision/collision_detection_behavior.dart
+++ b/packages/leap/lib/src/physical_behaviors/collision/collision_detection_behavior.dart
@@ -53,7 +53,7 @@ class CollisionDetectionBehavior extends PhysicalBehavior {
     _proxyHitboxForNonSolidHits();
     for (final other in _potentialHits) {
       if (!parent.isOtherSolid(other) && intersectsOther(_hitboxProxy, other)) {
-        collisionInfo.addCollision(other);
+        collisionInfo.addNonSolidCollision(other);
       }
     }
   }
@@ -85,12 +85,14 @@ class CollisionDetectionBehavior extends PhysicalBehavior {
         if (firstRightHit.isSlopeFromLeft) {
           if (velocity.y >= 0) {
             // Ignore slope underneath while moving upwards.
-            collisionInfo.downCollision = firstRightHit;
+            collisionInfo.addDownCollision(firstRightHit);
           } else {
-            collisionInfo.rightCollision = firstRightHit;
+            collisionInfo.addRightCollision(firstRightHit);
           }
         } else if (firstRightHit.left >= right) {
-          collisionInfo.rightCollision = firstRightHit;
+          _tmpHits
+              .where((c) => c.left == firstRightHit.left)
+              .forEach(collisionInfo.addRightCollision);
         }
       }
     }
@@ -109,12 +111,14 @@ class CollisionDetectionBehavior extends PhysicalBehavior {
           // Ignore slope underneath while moving upwards, should not collide
           // on left.
           if (velocity.y >= 0) {
-            collisionInfo.downCollision = firstLeftHit;
+            collisionInfo.addDownCollision(firstLeftHit);
           } else {
-            collisionInfo.leftCollision = firstLeftHit;
+            collisionInfo.addLeftCollision(firstLeftHit);
           }
         } else if (firstLeftHit.right <= left) {
-          collisionInfo.leftCollision = firstLeftHit;
+          _tmpHits
+              .where((c) => c.right == firstLeftHit.right)
+              .forEach(collisionInfo.addLeftCollision);
         }
       }
     }
@@ -146,8 +150,7 @@ class CollisionDetectionBehavior extends PhysicalBehavior {
           }
           return a.relativeTop(_hitboxProxy).compareTo(b.top);
         });
-        final firstBottomHit = _tmpHits.first;
-        collisionInfo.downCollision = firstBottomHit;
+        _tmpHits.forEach(collisionInfo.addDownCollision);
       }
     }
 
@@ -162,8 +165,7 @@ class CollisionDetectionBehavior extends PhysicalBehavior {
 
       if (_tmpHits.isNotEmpty) {
         _tmpHits.sort((a, b) => a.bottom.compareTo(b.bottom));
-        final firstTopHit = _tmpHits.first;
-        collisionInfo.upCollision = firstTopHit;
+        _tmpHits.forEach(collisionInfo.addUpCollision);
       }
     }
 
@@ -181,9 +183,9 @@ class CollisionDetectionBehavior extends PhysicalBehavior {
         final nextSlope = map.groundTiles[prevDown.gridX + 1]
             [prevDown.gridY + nextSlopeYDelta];
         if (prevDown.right >= left) {
-          collisionInfo.downCollision = prevDown;
+          collisionInfo.addDownCollision(prevDown);
         } else if (nextSlope != null && nextSlope.isSlopeFromRight) {
-          collisionInfo.downCollision = nextSlope;
+          collisionInfo.addDownCollision(nextSlope);
         }
       } else if (velocity.x < 0) {
         // Walking down slope to the left.
@@ -191,9 +193,9 @@ class CollisionDetectionBehavior extends PhysicalBehavior {
         final nextSlope = map.groundTiles[prevDown.gridX - 1]
             [prevDown.gridY + nextSlopeYDelta];
         if (prevDown.left <= right) {
-          collisionInfo.downCollision = prevDown;
+          collisionInfo.addDownCollision(prevDown);
         } else if (nextSlope != null && nextSlope.isSlopeFromLeft) {
-          collisionInfo.downCollision = nextSlope;
+          collisionInfo.addDownCollision(nextSlope);
         }
       }
     }

--- a/packages/leap/lib/src/physical_behaviors/collision/collision_info.dart
+++ b/packages/leap/lib/src/physical_behaviors/collision/collision_info.dart
@@ -22,69 +22,80 @@ import 'package:leap/leap.dart';
 /// [allCollisions] include all current solid and plus all non-solid entities
 /// that currently overlap or phased through.
 class CollisionInfo {
-  PhysicalEntity? _upCollision;
-  PhysicalEntity? _downCollision;
-  PhysicalEntity? _leftCollision;
-  PhysicalEntity? _rightCollision;
+  List<PhysicalEntity>? _upCollisions;
+  List<PhysicalEntity>? _downCollisions;
+  List<PhysicalEntity>? _leftCollisions;
+  List<PhysicalEntity>? _rightCollisions;
 
-  /// Entity that this is colliding with on top.
-  PhysicalEntity? get upCollision => _upCollision;
+  /// First solid entity that this is colliding with on top.
+  PhysicalEntity? get upCollision => _upCollisions?.firstOrNull;
 
-  set upCollision(PhysicalEntity? c) {
-    if (_upCollision != null) {
-      _allCollisions?.remove(c);
-    }
-    if (c != null) {
-      addCollision(c);
-    }
-    _upCollision = c;
+  /// All solid entities that this is colliding with on top.
+  List<PhysicalEntity> get upCollisions => _upCollisions ?? const [];
+
+  /// Order will be maintained, and the first up collision will
+  /// become the [upCollision] property
+  void addUpCollision(PhysicalEntity c) {
+    _upCollisions ??= [];
+    _upCollisions!.add(c);
+    _addCollision(c);
   }
 
-  /// Entity that this is colliding with on bottom.
-  PhysicalEntity? get downCollision => _downCollision;
+  /// First solid entity that this is colliding with on bottom.
+  PhysicalEntity? get downCollision => _downCollisions?.firstOrNull;
 
-  set downCollision(PhysicalEntity? c) {
-    if (_downCollision != null) {
-      _allCollisions?.remove(c);
-    }
-    if (c != null) {
-      addCollision(c);
-    }
-    _downCollision = c;
+  /// All solid entities that this is colliding with on bottom.
+  List<PhysicalEntity> get downCollisions => _downCollisions ?? const [];
+
+  void addDownCollision(PhysicalEntity c) {
+    _downCollisions ??= [];
+    _downCollisions!.add(c);
+    _addCollision(c);
   }
 
-  /// Entity that this is colliding with on left
-  PhysicalEntity? get leftCollision => _leftCollision;
+  /// First solid entity that this is colliding with on left.
+  PhysicalEntity? get leftCollision => _leftCollisions?.firstOrNull;
 
-  set leftCollision(PhysicalEntity? c) {
-    if (_leftCollision != null) {
-      _allCollisions?.remove(c);
-    }
-    if (c != null) {
-      addCollision(c);
-    }
-    _leftCollision = c;
+  /// All solid entities that this is colliding with on left.
+  List<PhysicalEntity> get leftCollisions => _leftCollisions ?? const [];
+
+  void addLeftCollision(PhysicalEntity c) {
+    _leftCollisions ??= [];
+    _leftCollisions!.add(c);
+    _addCollision(c);
   }
 
-  /// Entity that this is colliding with on right.
-  PhysicalEntity? get rightCollision => _rightCollision;
+  /// First solid entity that this is colliding with on right.
+  PhysicalEntity? get rightCollision => _rightCollisions?.firstOrNull;
 
-  set rightCollision(PhysicalEntity? c) {
-    if (_rightCollision != null) {
-      _allCollisions?.remove(c);
-    }
-    if (c != null) {
-      addCollision(c);
-    }
-    _rightCollision = c;
+  /// All solid entities that this is colliding with on right.
+  List<PhysicalEntity> get rightCollisions => _rightCollisions ?? const [];
+
+  void addRightCollision(PhysicalEntity c) {
+    _rightCollisions ??= [];
+    _rightCollisions!.add(c);
+    _addCollision(c);
   }
 
-  /// Non-solid collisions.
+  List<PhysicalEntity>? _nonSolidCollisions;
+
+  /// Non-solid collisions, overlapping.
+  List<PhysicalEntity> get nonSolidCollisions =>
+      _nonSolidCollisions ?? const [];
+
   List<PhysicalEntity>? _allCollisions;
 
+  /// Both solid & non-solid collisions. The solid collisions will be
+  /// touching but not overlapping.
   List<PhysicalEntity> get allCollisions => _allCollisions ?? const [];
 
-  void addCollision(PhysicalEntity collision) {
+  void addNonSolidCollision(PhysicalEntity c) {
+    _nonSolidCollisions ??= [];
+    _nonSolidCollisions!.add(c);
+    _addCollision(c);
+  }
+
+  void _addCollision(PhysicalEntity collision) {
     _allCollisions ??= [];
     _allCollisions!.add(collision);
   }
@@ -113,19 +124,44 @@ class CollisionInfo {
   }
 
   void reset() {
-    upCollision = null;
-    downCollision = null;
-    leftCollision = null;
-    rightCollision = null;
-
-    _allCollisions = null;
+    _upCollisions?.clear();
+    _downCollisions?.clear();
+    _leftCollisions?.clear();
+    _rightCollisions?.clear();
+    _nonSolidCollisions?.clear();
+    _allCollisions?.clear();
   }
 
   void copyFrom(CollisionInfo other) {
-    _upCollision = other.upCollision;
-    _downCollision = other.downCollision;
-    _leftCollision = other.leftCollision;
-    _rightCollision = other.rightCollision;
+    _upCollisions?.clear();
+    if (other.upCollisions.isNotEmpty) {
+      _upCollisions ??= [];
+      _upCollisions!.addAll(other.upCollisions);
+    }
+
+    _downCollisions?.clear();
+    if (other.downCollisions.isNotEmpty) {
+      _downCollisions ??= [];
+      _downCollisions!.addAll(other.downCollisions);
+    }
+
+    _leftCollisions?.clear();
+    if (other.leftCollisions.isNotEmpty) {
+      _leftCollisions ??= [];
+      _leftCollisions!.addAll(other.leftCollisions);
+    }
+
+    _rightCollisions?.clear();
+    if (other.rightCollisions.isNotEmpty) {
+      _rightCollisions ??= [];
+      _rightCollisions!.addAll(other.rightCollisions);
+    }
+
+    _nonSolidCollisions?.clear();
+    if (other.nonSolidCollisions.isNotEmpty) {
+      _nonSolidCollisions ??= [];
+      _nonSolidCollisions!.addAll(other.nonSolidCollisions);
+    }
 
     _allCollisions?.clear();
     if (other.allCollisions.isNotEmpty) {

--- a/packages/leap/lib/src/physical_behaviors/velocity/velocity_behavior.dart
+++ b/packages/leap/lib/src/physical_behaviors/velocity/velocity_behavior.dart
@@ -1,11 +1,17 @@
 import 'dart:math' as math;
 
-import 'package:leap/src/physical_behaviors/physical_behavior.dart';
+import 'package:leap/leap.dart';
 
 class VelocityBehavior extends PhysicalBehavior {
   @override
   void update(double dt) {
     super.update(dt);
+
+    if (parent.statuses
+        .where((s) => s is IgnoredByWorld || s is IgnoresVelocity)
+        .isNotEmpty) {
+      return;
+    }
 
     if (collisionInfo.up) {
       // Set the top of this to the bottom of the collision on top.


### PR DESCRIPTION
Refactoring `CollisionInfo` to allow client code to differentiate non-solid collisions from solid and to track multiple solid collisions in each direction. This means if a player is standing between two ground tiles (on level ground) both tiles should be in `collisionInfo.downCollisions`. The sorting order of the collisions is always the same, and `downCollision` will continue to return the same collision it always has (the first one). 

Also adding `debugCollisions` to `PhysicalEntity`

Also adding a `CharacterAnimation` component which extends `SpriteGroupAnimationComponent` and automatically handles positioning the animation properly around the parent's hitbox.

Also adding more status mixins to control collision detection and world interactions.